### PR TITLE
Inform visitor that NMDC Runtime will be offline on May 17

### DIFF
--- a/message.md
+++ b/message.md
@@ -1,1 +1,4 @@
+On May 17, 2024, the NMDC Runtime will be offline while some legacy identifiers are being replaced with NMDC persistent identifiers.
 
+- Start of downtime (actual): 11:30 AM PDT
+- End of downtime (estimate): 5:00 PM PDT


### PR DESCRIPTION
In this branch, I updated the web page to display a message saying that the NMDC Runtime will be offline on May 17 for re-ID-ing. The full message is in the diff.

Once this branch has been merged into `main`, the web page at https://status.microbiomedata.org/ will automatically update (within a couple minutes) to show the message.