### PR TITLE
Refine header styles, add local preview instructions, and create `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ into HTML, and renders it within the web page. The web page gets deployed to Git
 
 ## Commands
 
-- Preview web page locally: `$ uvx reloadserver` and visit [localhost:8000](http://localhost:8000)
+- Preview web page locally: `$ uvx reloadserver` and visit [http://localhost:8000](http://localhost:8000)
 
 ## Commonly-edited files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,20 +2,21 @@
 
 This repository contains a static web page NMDC team members use to display messages during outages
 and other special events. The web page fetches a Markdown file, uses Showdown to convert its content
-into HTML, and renders it within the web page.
+into HTML, and renders it within the web page. The web page gets deployed to GitHub Pages.
 
 ## Dependencies
 
-- Bootstrap 5 (loaded via CDN)
-- Google Fonts (for the `Arimo` font)
+- [Bootstrap 5](https://getbootstrap.com/docs/5.2/) (frontend framework), fetched from a CDN
+- [Google Fonts](https://fonts.google.com/specimen/Arimo) (for the `Arimo` font)
 - [Showdown](https://github.com/showdownjs/showdown) (to convert Markdown into HTML)
+- (Optional) [uv](https://docs.astral.sh/uv/) (for previewing the web page locally)
 
 ## Commands
 
-- Preview website locally: `$ uvx reloadserver` and visit [localhost:8000](http://localhost:8000)
+- Preview web page locally: `$ uvx reloadserver` and visit [localhost:8000](http://localhost:8000)
 
 ## Commonly-edited files
 
-- `index.css` - styles applied to `index.html`
-- `index.html` - web page (loads CSS, loads third-party JavaScript, and contains custom JavaScript)
+- `index.css` - Styles applied to `index.html`
+- `index.html` - Web page (loads CSS, loads third-party JavaScript, and contains custom JavaScript)
 - `message.md` - Markdown content that gets converted into HTML and injected into the web page

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+This repository contains a static web page NMDC team members use to display messages during outages
+and other special events. The web page fetches a Markdown file, uses Showdown to convert its content
+into HTML, and renders it within the web page.
+
+## Dependencies
+
+- Bootstrap 5 (loaded via CDN)
+- Google Fonts (for the `Arimo` font)
+- [Showdown](https://github.com/showdownjs/showdown) (to convert Markdown into HTML)
+
+## Commands
+
+- Preview website locally: `$ uvx reloadserver` and visit [localhost:8000](http://localhost:8000)
+
+## Commonly-edited files
+
+- `index.css` - styles applied to `index.html`
+- `index.html` - web page (loads CSS, loads third-party JavaScript, and contains custom JavaScript)
+- `message.md` - Markdown content that gets converted into HTML and injected into the web page

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ Write the text in Markdown format in the file `./message.md`, then reload the we
 
 If the `./message.md` file is empty, the web page will show a default message saying all systems are running normally.
 
+### Previewing the web page
+
+You can preview the web page locally by running the following command (which will start up a web
+server that reloads the page whenever the web page's source files change) and visiting [http://localhost:8000](http://localhost:8000).
+
+```sh
+uvx reloadserver
+```
+
+You can terminate the web server by pressing `^C`.
+
+> Note: You can get `uvx` by installing [uv](https://docs.astral.sh/uv/). We opted to document a
+> `uv/uvx`-based procedure here because many NMDC team members already have `uv` installed on their
+> development machines.
+
 ### Deployment
 
 GitHub will automatically deploy the latest commit on the `main` branch, to GitHub Pages.

--- a/index.css
+++ b/index.css
@@ -75,6 +75,33 @@
 }
 
 /* Message */
+#nmdc-message h1 {
+  font-size: 23px;
+  line-height: 27.6px;
+}
+#nmdc-message h2 {
+  font-size: 20px;
+  line-height: 24px;
+}
+#nmdc-message h3 {
+  font-size: 16px;
+  line-height: 19.2px;
+}
+#nmdc-message h4 {
+  font-size: 16px;
+  line-height: 19.2px;
+  color: var(--bs-gray-700);
+}
+#nmdc-message h5 {
+  font-size: 16px;
+  line-height: 19.2px;
+  color: var(--bs-gray-600);
+}
+#nmdc-message h6 {
+  font-size: 16px;
+  line-height: 19.2px;
+  color: var(--bs-gray-500);
+}
 #nmdc-message p {
   color: var(--nmdc-black);
 }

--- a/message.md
+++ b/message.md
@@ -1,3 +1,3 @@
-#### Upcoming maintenance (July 22 - 28)
+# Upcoming maintenance (July 22 - 28)
 
 Data file downloads will be unavailable from Wednesday, July 22 through Tuesday, July 28 (PDT) while our storage provider performs an infrastructure upgrade.


### PR DESCRIPTION
On this branch, I refined the styles of the Markdown headers so maintainers don't have to remember to use an `h4`, specifically, as the top-level header within `message.md`. Now, they can treat it like an arbitrary Markdown file and use an `h1` as its highest-level header.

I also added instructions for previewing the web page locally, using a web server that has automatic reloading built in.

Finally, I created an `AGENTS.md` file to facilitate agentic maintenance of the message.